### PR TITLE
Enable allow self signed certificates mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ podman run --rm  --env CE_QMGR=QM1 --env CE_QUEUE=DEV.QUEUE.2 localhost/mq-consu
 ```
 
 #### Testing with a containerised queue manager
-If you are testing with a default containerised queue manager, then it's certificate will be self signed. 
+If you are testing with a default containerised queue manager, then its certificate will be self signed. 
 
 Observer attempts to get queue depths will fail with 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,17 @@ podman run --rm  --env TEST=1 --rm localhost/mq-observer:latest
 podman run --rm  --env CE_QMGR=QM1 --env CE_QUEUE=DEV.QUEUE.2 localhost/mq-consumer:latest
 ```
 
+#### Testing with a containerised queue manager
+If you are testing with a default containerised queue manager, then it's certificate will be self signed. 
+
+Observer attempts to get queue depths will fail with 
+
+```
+tls: failed to verify certificate: x509: certificate signed by unknown authority"
+```
+
+To test against such queue managers run with the envrionment option `ALLOW_SELF_SIGNED=1`
+
 ### 3. Run deploy script
 Run the `.deploy.sh` to ensure that the observer application and sample consumer job and the associated secrets and configmaps are created and start. 
 

--- a/observer/constant/constants.go
+++ b/observer/constant/constants.go
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 IBM Corp.
+ * Copyright 2024, 2025 IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/observer/constant/constants.go
+++ b/observer/constant/constants.go
@@ -50,6 +50,7 @@ const KEY_CODEENGINE_REFRESH_DURATION = "CE_REFRESH_INTERVAL"
 
 const key_running_test_mode = "TEST"
 const key_drop_bad = "DROP_BAD"
+const key_allow_self_signed = "ALLOW_SELF_SIGNED"
 
 const key_no_cos = "NO_COS"
 const use_cos_storage = true
@@ -126,6 +127,7 @@ const default_test_ce_refresh_duration = 5 * time.Minute
 const default_ce_refresh_duration = 10 * time.Minute
 
 const drop_bad_registrations = false
+const default_allow_self_signed = false
 
 const MAX_NOSTORE_ITERATIONS = 2 // 10
 
@@ -176,6 +178,15 @@ func DetermineInterval(key string) time.Duration {
 	} else {
 		return default_sleep_interval
 	}
+}
+
+func AllowSelfSigned() bool {
+	if 0 < len(os.Getenv(key_allow_self_signed)) {
+		return true
+	} else if _, runningInTest := os.LookupEnv(key_running_test_mode); runningInTest {
+		return default_allow_self_signed
+	}
+	return false
 }
 
 func DropBadRegistrations() bool {

--- a/observer/constant/constants.go
+++ b/observer/constant/constants.go
@@ -128,6 +128,7 @@ const default_ce_refresh_duration = 10 * time.Minute
 
 const drop_bad_registrations = false
 const default_allow_self_signed = false
+const default_test_allow_self_signed = false
 
 const MAX_NOSTORE_ITERATIONS = 2 // 10
 
@@ -184,9 +185,9 @@ func AllowSelfSigned() bool {
 	if 0 < len(os.Getenv(key_allow_self_signed)) {
 		return true
 	} else if _, runningInTest := os.LookupEnv(key_running_test_mode); runningInTest {
-		return default_allow_self_signed
+		return default_test_allow_self_signed
 	}
-	return false
+	return default_allow_self_signed
 }
 
 func DropBadRegistrations() bool {

--- a/observer/notifications/invoker.go
+++ b/observer/notifications/invoker.go
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 IBM Corp.
+ * Copyright 2024, 2025 IBM Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/observer/notifications/invoker.go
+++ b/observer/notifications/invoker.go
@@ -38,13 +38,11 @@ type invoker struct {
 }
 
 func (i *invoker) createClient() {
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 	if constant.AllowSelfSigned() {
-		customTransport := http.DefaultTransport.(*http.Transport).Clone()
 		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-		i.client = &http.Client{Timeout: 30 * time.Second, Transport: customTransport}
-	} else {
-		i.client = &http.Client{Timeout: 30 * time.Second}
 	}
+	i.client = &http.Client{Timeout: 30 * time.Second, Transport: customTransport}
 }
 
 // func (i *invoker) pokerDecided(eventNotifier poker) {

--- a/observer/notifications/invoker.go
+++ b/observer/notifications/invoker.go
@@ -17,6 +17,7 @@
 package notifications
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strings"
 	"time"
@@ -37,7 +38,13 @@ type invoker struct {
 }
 
 func (i *invoker) createClient() {
-	i.client = &http.Client{Timeout: 30 * time.Second}
+	if constant.AllowSelfSigned() {
+		customTransport := http.DefaultTransport.(*http.Transport).Clone()
+		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		i.client = &http.Client{Timeout: 30 * time.Second, Transport: customTransport}
+	} else {
+		i.client = &http.Client{Timeout: 30 * time.Second}
+	}
 }
 
 // func (i *invoker) pokerDecided(eventNotifier poker) {


### PR DESCRIPTION
Enable an environment variable which will switch the TLS transport layer to allow a queue depth check against queue managers with self-signed certificates. The mode is disabled by default, even in test mode.